### PR TITLE
add some docs on user image and accessing patient data

### DIFF
--- a/preliminary.md
+++ b/preliminary.md
@@ -19,3 +19,56 @@ The first instance of a JupyterHealth deployment is a proof-of-concept, or "pre 
 ## JupyterHub
 
 The pre MVP hub is deployed by 2i2c using their [Managed JupyterHubs Service](https://infrastructure.2i2c.org). The configuration for it is in the [2i2c infrastructure repository](https://github.com/2i2c-org/infrastructure/tree/main/config/clusters/jupyter-health).
+
+The image specifying the user environment is deployed from the [jupyterhealth/singleuser-image](https://github.com/jupyterhealth/singleuser-image) repo
+and hosted at https://quay.io/repository/jupyterhealth/singleuser-premvp.
+
+The user image is based on the `jupyter/scipy-notebook` image.
+
+The user image also contains a `jupyter_health` package (not yet published as a package available elsewhere),
+which provides a `JupyterHealthCHClient` class, which loads credentials from the environment, so needs no arguments:
+
+```python
+from jupyter_health import JupyterHealthCHClient
+
+ch_client = JupyterHealthCHClient()
+```
+
+### Registering new patients
+
+New patients can be registered with deep links:
+
+```python
+deep_link = ch_client.construct_authorization_request_deeplink(
+    "patient-id",
+    scope="OMHealthResource.HeartRate.Read OMHealthResource.BloodPressure.Read",
+    expiration_seconds=2592000,
+)
+print(deep_link)
+```
+
+The resulting URL can be shared with patients to start uploading data to CommonHealth Cloud.
+
+### Fetching patient data
+
+Once a patient is enrolled and has uploaded some data,
+patient data can be fetched using the patient id/name used when creating the deep link:
+
+```python
+records = ch_client.fetch_data("patient-id")
+```
+
+Each record is a `ResourceHolder` instance, where `json_content` contains the actual data.
+`json_content` has a `header` with metadata identifying the schema, and a `body` containing the measurement itself.
+To extract blood pressure measurements:
+
+```python
+bp_readings = [
+    record.json_content["body"]
+    for record in records
+    if record.resource_type == "BLOOD_PRESSURE"
+]
+```
+
+Which will select the data according to the openmhealth blood pressure schema.
+These readings can then be passed to a plotting utility like [this one](./examples/openmhealth-bp).

--- a/security.md
+++ b/security.md
@@ -2,9 +2,9 @@
 title: Security Overview
 ---
 
-# Introduction
+## Introduction
 
-The JupyterHealth Pre-MVP security focuses on establishing a secure privacy perserving transmission of patient data from:
+The JupyterHealth Pre-MVP security focuses on establishing a secure privacy-preserving transmission of patient data from:
 
 ```mermaid
 flowchart LR
@@ -14,7 +14,7 @@ flowchart LR
   D[Partner Data Store]
 ```
 
-# API Credentials
+## API Credentials
 
 - CommonHealth Application will authenticate with the Medical Device API using:
   - Client ID
@@ -24,14 +24,49 @@ flowchart LR
   - Client ID
   - Client Secret
 
-# Encryption
+### API credentials in JupyterHub
+
+The JupyterHealth pre-MVP application is registered as a Partner application (two, actually - one 'prod' to represent the pre-MVP itself, and one 'testing' for testing configurations).
+
+There are two partner applications registered:
+
+- 'prod' represents the pre-MVP
+- 'testing' for testing out functionality
+
+These credentials are stored in AWS SecretManager:
+
+- `ch-cloud-creds-{name}` contains the partner id, client id/secret, etc. required to access the CommonHealth Cloud API
+- `ch-cloud-storage-{name}` contains the state of the CH Cloud "storage delegate".
+  This is the local storage of:
+  - decryption keys for patient data
+  - patient id/uuid mapping
+
+The JupyterHub user 'role' is granted read access to `ch-cloud-creds-{name}` and read/write access to `ch-cloud-storage-{name}`.
+
+#### Pre-MVP considerations
+
+In the pre-MVP, from the perspective of CommonHealth cloud and data access, all JupyterHub users are equivalent and indistinguishable and act collectively _as_ the pre-MVP.
+That is, all JupyterHub users have:
+
+- read access to the client id/secret to access the API in order to:
+  - create new deep links to register users
+  - fetch encrypted patient data
+- read/write access to the decryption key for decrypting patient data
+- read/write access to the patient id mapping to identify patients and store new patient id mappings
+
+Following the pre-MVP, users will login to JupyterHub with SMART-on-FHIR as an OAuth provider,
+and will authenticate directly _as themselves_ via scoped access tokens,
+rather than always acting as the partner application.
+This will allow per-user access control, registered and enforced by SMART-on-FHIR, outside JupyterHub.
+
+## Encryption
 
 - Each Partner will generate a set of Private/Public keys that will used for encryption and decryption of patient data.
 - The Partner Public encryption key will be stored in the CloudStorage Service.
 - The CommonHealth Application will use the Partner's Public Key to encrypt the patient data before storing it in the CloudStorage Service.
 - The Partner's Private Key will be used to decrypt the patient data when retrieved from the CloudStorage Service.
 
-# Cryptography
+## Cryptography
 
 - Google Tink is utilized for client-side as well as server-side cryptography.
 
@@ -43,6 +78,6 @@ flowchart LR
 
   - Signing key(s) for TrustedPartners: ECDSA_P256
 
-# Data Flow Diagram
+## Data Flow Diagram
 
 ![](CHCS-Architecture.png)


### PR DESCRIPTION
- document user image location and contents
- document credentials for the API and how they are loaded for users
- explain how the pre-MVP will differ from the next deployment with smart-on-fhir
- example for creating deep link
- example for fetching data which can be passed to @ryanlovett's plotting example
