### PR TITLE
Allow yaml to have multiple documents.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-json
       - id: check-yaml
+        args: [--allow-multiple-documents]
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.21
     hooks:


### PR DESCRIPTION
This is so I can add an example doc containing kubernetes resources.