### PR TITLE
build myst on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+build:
+  os: "ubuntu-24.04"
+  tools:
+    nodejs: "22"
+  commands:
+    - npm ci
+    - mkdir -p $READTHEDOCS_OUTPUT/html/
+    - BASE_URL="/$READTHEDOCS_LANGUAGE/$READTHEDOCS_VERSION" npm run myst -- build -d --html
+    - cp -a _build/html/. "$READTHEDOCS_OUTPUT/html"
+    - rm -r _build


### PR DESCRIPTION
this doesn't change hosting (though the public docs builds will exist, so we _could_ switch to RTD hosting), but it gets us pull request previews, which are nice