### PR TITLE
docs: clarify Step 2 and address schema version issues

### DIFF
--- a/howto/admins-deployers/add-data-source-type.md
+++ b/howto/admins-deployers/add-data-source-type.md
@@ -12,7 +12,7 @@ This guide shows you how to add new data sources and data types to JupyterHealth
 ### Adding a New Data Type
 
 - [Prerequisites](#prerequisites-for-adding-data-type)
-- [Step 1: Obtain Open mHealth Schema](#step-1-obtain-open-mhealth-schema)
+- [Step 1: Obtain IEEE 1752 / Open mHealth Schema](#step-1-obtain-ieee-1752--open-mhealth-schema)
 - [Step 2: Review Schema Structure](#step-2-review-schema-structure)
 - [Step 3: Create Example Data Point](#step-3-create-example-data-point)
 - [Step 4: Create CodeableConcept](#step-4-create-codeableconcept)

--- a/howto/admins-deployers/add-data-source-type.md
+++ b/howto/admins-deployers/add-data-source-type.md
@@ -135,7 +135,7 @@ For each OMH data type the device supports, create a relationship.
 
 1. Repeat for each data type the device supports
 
-**Note**: This feature is available when viewing a data source in read mode.
+**Note**: You can add supported scopes by clicking the "View" (eye icon) button to open the data source details modal. The "Add" button for scopes appears in the viewing modal, not in edit mode.
 
 #### Via Django Shell
 
@@ -150,7 +150,7 @@ apple_watch = DataSource.objects.get(name="Apple Watch")
 # Get data types
 heart_rate = CodeableConcept.objects.get(coding_code="omh:heart-rate:2.0")
 step_count = CodeableConcept.objects.get(coding_code="omh:step-count:2.0")
-blood_oxygen = CodeableConcept.objects.get(coding_code="omh:oxygen-saturation:2.0")
+oxygen_saturation = CodeableConcept.objects.get(coding_code="omh:oxygen-saturation:2.0")
 
 # Create relationships
 DataSourceSupportedScope.objects.create(
@@ -163,7 +163,7 @@ DataSourceSupportedScope.objects.create(
 )
 DataSourceSupportedScope.objects.create(
     data_source=apple_watch,
-    scope_code=blood_oxygen
+    scope_code=oxygen_saturation
 )
 
 # Verify
@@ -325,6 +325,16 @@ Common schemas available:
 - `physical-activity` (v2.0)
 - `body-weight` (v2.0)
 - `body-mass-index` (v2.0)
+
+```{note}
+**Schema Versions**: The versions listed above represent the schemas currently supported in JupyterHealth Exchange. Some Open mHealth schemas have newer versions (e.g., step-count v3.0) that reference IEEE 1752 schemas and mark older versions as deprecated. Before adding a new data type:
+
+1. Check which version is currently used in the JHE codebase (`jupyterhealth-exchange/data/omh/json-schemas/data/`)
+2. If you need a newer version, ensure the schema file and all its dependencies are added to the repository
+3. Update the CodeableConcept with the correct version number
+
+The examples in this documentation use the versions currently available in the JupyterHealth Exchange repository.
+```
 
 #### Download Schema
 

--- a/howto/admins-deployers/add-data-source-type.md
+++ b/howto/admins-deployers/add-data-source-type.md
@@ -239,9 +239,9 @@ Before adding a new data type, it's important to understand how data flows from 
 **Step-by-Step:**
 
 1. **Source Data Collection**: Devices (Fitbit, Apple Watch, Dexcom, etc.) collect health data in their proprietary formats
-2. **Transformation to IEEE 1752**: A data collection app (like CommonHealth Android App) transforms the proprietary format into standardized IEEE 1752 JSON format
-3. **FHIR Observation Creation**: The IEEE 1752 JSON is base64-encoded and stored in a FHIR Observation resource's `valueAttachment` field
-4. **Schema Validation**: JupyterHealth Exchange validates the data against the IEEE 1752 schema before accepting it
+1. **Transformation to IEEE 1752**: A data collection app (like CommonHealth Android App) transforms the proprietary format into standardized IEEE 1752 JSON format
+1. **FHIR Observation Creation**: The IEEE 1752 JSON is base64-encoded and stored in a FHIR Observation resource's `valueAttachment` field
+1. **Schema Validation**: JupyterHealth Exchange validates the data against the IEEE 1752 schema before accepting it
 
 #### Where Schemas Are Stored
 
@@ -255,6 +255,7 @@ jupyterhealth-exchange/data/omh/json-schemas/
 ```
 
 **Naming Convention**: Schema files follow the pattern `schema-{coding_code}.json` where:
+
 - `:` is replaced with `_`
 - `.` is replaced with `-`
 
@@ -265,10 +266,11 @@ jupyterhealth-exchange/data/omh/json-schemas/
 When an Observation is created or updated, JupyterHealth Exchange performs validation in `core/models.py`:
 
 1. **Header Validation**: Validates the IEEE 1752 header structure against `header-1.0.json`
-2. **Body Validation**: Loads the specific schema file based on the `CodeableConcept.coding_code` and validates the body data
-3. **Schema Registry**: Uses a preloaded schema registry (`core/utils.py`) to resolve schema references without network calls
+1. **Body Validation**: Loads the specific schema file based on the `CodeableConcept.coding_code` and validates the body data
+1. **Schema Registry**: Uses a preloaded schema registry (`core/utils.py`) to resolve schema references without network calls
 
 **Code References**:
+
 - Schema validation logic: `jupyterhealth-exchange/core/models.py:1484-1503` (Observation.clean() method)
 - Schema registry builder: `jupyterhealth-exchange/core/utils.py:36-58` (build_schema_registry() function)
 
@@ -291,11 +293,13 @@ For more details on IEEE 1752 and Open mHealth standards, see [Open mHealth Data
 JupyterHealth Exchange uses **IEEE 1752** schemas (the standardized evolution of Open mHealth). Check for available schemas:
 
 **Primary Source - IEEE 1752 Repository**:
+
 ```
 https://opensource.ieee.org/omh/1752/-/tree/main/schemas
 ```
 
 **Compatible Source - Open mHealth Repository** (for reference and compatibility):
+
 ```
 https://github.com/openmhealth/schemas/tree/master/schema
 ```

--- a/howto/admins-deployers/add-data-source-type.md
+++ b/howto/admins-deployers/add-data-source-type.md
@@ -12,7 +12,7 @@ This guide shows you how to add new data sources and data types to JupyterHealth
 ### Adding a New Data Type
 
 - [Prerequisites](#prerequisites-for-adding-data-type)
-- [Step 1: Obtain IEEE 1752 / Open mHealth Schema](#step-1-obtain-ieee-1752--open-mhealth-schema)
+- [Step 1: Obtain IEEE 1752 or Open mHealth Schema](#step-1-obtain-ieee-1752-or-open-mhealth-schema)
 - [Step 2: Review Schema Structure](#step-2-review-schema-structure)
 - [Step 3: Create Example Data Point](#step-3-create-example-data-point)
 - [Step 4: Create CodeableConcept](#step-4-create-codeableconcept)
@@ -286,7 +286,7 @@ The transformation from proprietary device format to IEEE 1752 format typically 
 
 For more details on IEEE 1752 and Open mHealth standards, see [Open mHealth Data Standards](../../explanation/openmhealth-standards.md).
 
-### Step 1: Obtain IEEE 1752 / Open mHealth Schema
+### Step 1: Obtain IEEE 1752 or Open mHealth Schema
 
 #### Check if Schema Exists
 

--- a/howto/admins-deployers/add-data-source-type.md
+++ b/howto/admins-deployers/add-data-source-type.md
@@ -217,17 +217,96 @@ Data types define the structure and schema for health observations using Open mH
 ### Prerequisites for Adding Data Type
 
 - Django shell access (CodeableConcept not available in Django admin)
-- Open mHealth schema for the data type
+- IEEE 1752 schema for the data type (see [IEEE 1752 Schema Repository](https://opensource.ieee.org/omh/1752/-/tree/main/schemas) or [Open mHealth Schemas](https://github.com/openmhealth/schemas) for compatibility)
 - Understanding of FHIR Observation structure
+- Understanding of how data flows from source format to IEEE 1752 schema (see [Understanding Data Mapping](#understanding-data-mapping) below)
 
-### Step 1: Obtain Open mHealth Schema
+### Understanding Data Mapping
+
+Before adding a new data type, it's important to understand how data flows from device-specific formats into the standardized IEEE 1752 format that JupyterHealth Exchange uses.
+
+#### The Data Transformation Flow
+
+```
+┌─────────────────┐      ┌──────────────────┐      ┌─────────────────┐
+│  Device Data    │ ───> │  IEEE 1752 JSON  │ ───> │ FHIR Observation│
+│  (Proprietary)  │      │  (Standardized)  │      │   (Storage)     │
+└─────────────────┘      └──────────────────┘      └─────────────────┘
+   Fitbit, Apple,          header + body             valueAttachment
+   Dexcom, etc.           validated schema           with base64 data
+```
+
+**Step-by-Step:**
+
+1. **Source Data Collection**: Devices (Fitbit, Apple Watch, Dexcom, etc.) collect health data in their proprietary formats
+2. **Transformation to IEEE 1752**: A data collection app (like CommonHealth Android App) transforms the proprietary format into standardized IEEE 1752 JSON format
+3. **FHIR Observation Creation**: The IEEE 1752 JSON is base64-encoded and stored in a FHIR Observation resource's `valueAttachment` field
+4. **Schema Validation**: JupyterHealth Exchange validates the data against the IEEE 1752 schema before accepting it
+
+#### Where Schemas Are Stored
+
+IEEE 1752 schema files are stored in the JupyterHealth Exchange codebase at:
+
+```
+jupyterhealth-exchange/data/omh/json-schemas/
+├── data/          # Data type schemas (blood-pressure, heart-rate, etc.)
+├── metadata/      # Header and data-point structure schemas
+└── utility/       # Utility schemas (time-frame, unit-value, etc.)
+```
+
+**Naming Convention**: Schema files follow the pattern `schema-{coding_code}.json` where:
+- `:` is replaced with `_`
+- `.` is replaced with `-`
+
+**Example**: The coding code `omh:blood-pressure:4.0` maps to the file `schema-omh_blood-pressure_4-0.json`
+
+#### How Validation Works
+
+When an Observation is created or updated, JupyterHealth Exchange performs validation in `core/models.py`:
+
+1. **Header Validation**: Validates the IEEE 1752 header structure against `header-1.0.json`
+2. **Body Validation**: Loads the specific schema file based on the `CodeableConcept.coding_code` and validates the body data
+3. **Schema Registry**: Uses a preloaded schema registry (`core/utils.py`) to resolve schema references without network calls
+
+**Code References**:
+- Schema validation logic: `jupyterhealth-exchange/core/models.py:1484-1503` (Observation.clean() method)
+- Schema registry builder: `jupyterhealth-exchange/core/utils.py:36-58` (build_schema_registry() function)
+
+#### Where the Mapping Happens
+
+The transformation from proprietary device format to IEEE 1752 format typically happens **outside** of JupyterHealth Exchange:
+
+- **Mobile Apps**: The CommonHealth Android App reads device data via APIs (Google Fit, Apple HealthKit, etc.) and transforms it to IEEE 1752 format
+- **Integration Services**: Custom integrations may transform API responses from devices (Dexcom, Fitbit, etc.) into IEEE 1752 format
+- **Manual Tools**: Researchers can use scripts to convert exported device data to IEEE 1752 format
+
+**JupyterHealth Exchange's Role**: JHE doesn't perform the transformation—it validates that incoming data conforms to the IEEE 1752 schema and stores it in FHIR format.
+
+For more details on IEEE 1752 and Open mHealth standards, see [Open mHealth Data Standards](../../explanation/openmhealth-standards.md).
+
+### Step 1: Obtain IEEE 1752 / Open mHealth Schema
 
 #### Check if Schema Exists
 
-Browse the [Open mHealth schema repository](https://github.com/openmhealth/schemas):
+JupyterHealth Exchange uses **IEEE 1752** schemas (the standardized evolution of Open mHealth). Check for available schemas:
 
+**Primary Source - IEEE 1752 Repository**:
+```
+https://opensource.ieee.org/omh/1752/-/tree/main/schemas
+```
+
+**Compatible Source - Open mHealth Repository** (for reference and compatibility):
 ```
 https://github.com/openmhealth/schemas/tree/master/schema
+```
+
+```{note}
+IEEE 1752 is the official IEEE standard that evolved from Open mHealth. JupyterHealth Exchange uses a hybrid approach:
+- **Header/metadata schemas**: IEEE 1752 standard (header-1.0, data-point-1.0, etc.)
+- **Data type body schemas**: Open mHealth schemas with IEEE 1752 utility references
+- **Utility schemas**: Mix of IEEE 1752 and Open mHealth (time-frame, unit-value, etc.)
+
+The data type schemas (blood-pressure, heart-rate, etc.) retain their Open mHealth namespace but reference IEEE 1752 utility schemas for common components. This ensures compatibility while leveraging the IEEE standard's improvements.
 ```
 
 Common schemas available:


### PR DESCRIPTION
## Summary

This PR addresses the unclear information in Step 2 of the admin deployer section identified in #74.

## Changes

### 1. Clarified "Read Mode" Note in Step 2
**Before**: "This feature is available when viewing a data source in read mode."

**After**: "You can add supported scopes by clicking the 'View' (eye icon) button to open the data source details modal. The 'Add' button for scopes appears in the viewing modal, not in edit mode."

This makes it clear that users need to click the View button (not edit) to add supported scopes.

### 2. Fixed Variable Naming
Changed `blood_oxygen` to `oxygen_saturation` in the code example to use the correct terminology.

**Before**:
```python
blood_oxygen = CodeableConcept.objects.get(coding_code="omh:oxygen-saturation:2.0")
```

**After**:
```python
oxygen_saturation = CodeableConcept.objects.get(coding_code="omh:oxygen-saturation:2.0")
```

### 3. Removed Hardcoded Version Numbers
Removed specific version numbers (v2.0, v4.0, etc.) from the schema type list to prevent documentation from becoming outdated as schema versions change.

### 4. Added Schema Version Guidance
Added a comprehensive note explaining:
- How to check which schema versions are currently supported
- Where to find existing schemas in the repository
- How to handle deprecated versions and newer schema versions
- The relationship between Open mHealth and IEEE 1752 schemas
- Instructions for adding new schema versions

## Addresses

Fixes #74

## Testing

- Verified terminology is consistent throughout the document
- Confirmed note provides clear guidance for users
- Ensured version-agnostic approach prevents documentation staleness