### PR TITLE
docs: remove references to patient console access

### DIFF
--- a/explanation/rbac-governance.md
+++ b/explanation/rbac-governance.md
@@ -13,18 +13,24 @@ JHE has three distinct user types with different authorization models:
 
 ### 1. Patient
 
-**Authorization Model**: Self-access with full control over own data
+**Authorization Model**: API-only access with full control over own data
 
-**Capabilities**:
+```{important}
+**No Console Access**: Patients do NOT have access to the JupyterHealth Exchange Console. The Console is for Practitioners and Admins only. Patients interact with JupyterHealth through:
+- **CommonHealth mobile app** (primary patient interface)
+- **Direct API calls** (for programmatic access)
+```
+
+**Capabilities** (via API or mobile app):
 
 - View own patient record and consent status
 - Modify own consent decisions per study and data type
-- Upload health data to JHE (via CommonHealth app)
+- Upload health data to JHE (via CommonHealth app or FHIR API)
 - Cannot access other patients' data under any circumstances
 
-**No Role Assignment**: Patients do not have roles. They always have complete access to their own records and consent management without requiring organization membership or role assignments.
+**No Role Assignment**: Patients do not have roles. They always have complete access to their own records and consent management via API without requiring organization membership or role assignments.
 
-**Organization Membership**: Patients can be members of multiple organizations via `PatientOrganization` relationships. This membership determines which organizations' studies they can see and consent to, but does not grant them access to organizational management functions.
+**Organization Membership**: Patients can be members of multiple organizations via `PatientOrganization` relationships. This membership determines which organizations' studies they can see and consent to via API, but does not grant them access to the Console or organizational management functions.
 
 ### 2. Practitioner
 

--- a/howto/admins-deployers/add-data-source-type.md
+++ b/howto/admins-deployers/add-data-source-type.md
@@ -497,21 +497,13 @@ Reference: `jupyterhealth-exchange/core/views/study.py`
 
 ### Step 3: Grant Patient Consent
 
-#### Using JupyterHealth Exchange Console
+```{note}
+**JHE Console Access**: The JupyterHealth Exchange Console is for **Practitioners and Admins only**. Patients cannot and should not log into the Console. Patient consent is managed either:
+- By practitioners via the Console (on behalf of patients)
+- By patients via API or mobile app (CommonHealth)
+```
 
-**Option A: As a Patient**
-
-1. Login as a patient user (e.g., `peter@example.com`, `pamela@example.com`)
-
-1. Navigate to the **Patients** section and view your patient profile
-
-1. In the **Studies Pending Consent** section, you'll see studies requesting data access
-
-1. Review the requested data types/scopes
-
-1. Click the checkbox or consent button to grant access to the requested data
-
-**Option B: As a Practitioner (Manager or Member)**
+#### Using JupyterHealth Exchange Console (Practitioners Only)
 
 Practitioners with **manager** or **member** roles can grant consent on behalf of patients:
 
@@ -525,7 +517,7 @@ Practitioners with **manager** or **member** roles can grant consent on behalf o
 
 **Note**: Practitioners with **viewer** role cannot grant consent.
 
-#### Via API
+#### Via API (Patients or Practitioners)
 
 ```bash
 # Patient consents to share step count data


### PR DESCRIPTION
## Summary

Removes all documentation references to patients logging into JHE Console, as patients should not have Console access.

## Problem

Issue #73 identified that patients can currently log into JHE Console but see blank screens with no functionality. After investigation, we determined that **patients should NOT have Console access at all**.

## Changes

### 1. Updated add-data-source-type.md (Step 3: Grant Patient Consent)

**Removed**:
- "Option A: As a Patient" workflow that described patients using the Console

**Added**:
- Prominent note that JHE Console is for Practitioners and Admins only
- Clarification that patient consent is managed via:
  - Practitioners in the Console (on behalf of patients)
  - Patients via API or CommonHealth mobile app

### 2. Updated rbac-governance.md (Patient section)

**Added**:
- Important note box stating patients do NOT have Console access
- Clarification that CommonHealth mobile app is the primary patient interface
- Updated "Capabilities" section to emphasize API/mobile app only
- Changed authorization model description to "API-only access"

**Updated**:
- All patient capability descriptions now specify "via API or mobile app"
- Organization membership section clarifies no Console access

## Related Issues

- Fixes #73 (documentation issue)
- Related: jupyterhealth/jupyterhealth-exchange#233 (platform issue to block patient login)

## Rationale

The Console is designed for practitioners and admins to manage studies, patients, and data. Patients interact with JupyterHealth via:
- **CommonHealth mobile app** for uploading data and managing consent
- **Direct API calls** for programmatic access
- **NOT** the JHE Console

This change corrects misleading documentation that suggested patients should use the Console.

## Testing

- Verified all formatting renders correctly
- Confirmed no broken links introduced
- Changes align with actual JHE implementation