### PR TITLE
docs: Provider EHR launch (token exchange) page + MedPlum dashboard tutorial

### DIFF
--- a/jhe/provider-ehr-launch.md
+++ b/jhe/provider-ehr-launch.md
@@ -28,12 +28,15 @@ This is the **provider-side** sibling of the patient-side
 clinical data *into* JHE; this flow lets a provider's launched app read JHE data *out*,
 as that provider, under JHE's normal access control.
 
+<!-- TODO(flip-to-ready): the oidc_verify.py and test_token_exchange.py links below
+     point at the feature branch; switch them to jupyterhealth-exchange main when PR #646
+     merges and this PR is marked ready. -->
 | What                                   | Where                                                                                                                                                                                      |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Token-exchange endpoint                | [`core/views/common.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/views/common.py) (`token_exchange`)                                                        |
-| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/oidc_verify.py)                                                                             |
+| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/the-commons-project/jupyterhealth-exchange/blob/ehr-launch-jhe-sso-with-client/core/oidc_verify.py)                                                                             |
 | Client + settings seed                 | [`core/management/commands/seed.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/management/commands/seed.py) (`seed_sof_ehr_launch_application`, `auth.sof.*`) |
-| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/tests/backend/test_token_exchange.py)                                           |
+| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/the-commons-project/jupyterhealth-exchange/blob/ehr-launch-jhe-sso-with-client/tests/backend/test_token_exchange.py)                                           |
 | Reference app (template)               | [jupyterhealth-sof-provider-template](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template) — see also the [MedPlum tutorial](../tutorial/medplum-provider-dashboard.md)   |
 
 ## Architecture

--- a/jhe/provider-ehr-launch.md
+++ b/jhe/provider-ehr-launch.md
@@ -1,0 +1,171 @@
+---
+title: Provider EHR Launch (SMART on FHIR)
+---
+
+An external **SMART on FHIR provider app** — launched from an EHR like Epic, Cerner, or
+MedPlum — can trade the EHR-issued OIDC **`id_token`** for a **JHE user-bound access
+token** over OAuth 2.0 Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)).
+The provider logs in once, at the EHR; there is no second JHE login.
+
+JHE verifies the `id_token` **offline against the EHR's JWKS** (discovered from
+`{iss}/.well-known/smart-configuration`), identifies the provider from the **`fhirUser`**
+claim, and issues its own access token bound to the matching JHE `Practitioner`. No EHR
+`userinfo` or introspection endpoint is required — verification relies only on
+capabilities every ONC §170.315(g)(10)-certified EHR must expose (OIDC `id_token` with
+`fhirUser` + published JWKS), so the same code path works across EHR vendors with no
+per-vendor plumbing.
+
+This is the **provider-side** sibling of the patient-side
+[MyChart (Epic) integration](./mychart-integration.md): MyChart pulls a patient's
+clinical data *into* JHE; this flow lets a provider's launched app read JHE data *out*,
+as that provider, under JHE's normal access control.
+
+| What                                   | Where                                                                                                                                                                                        |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Token-exchange endpoint                | [`core/views/common.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/views/common.py) (`token_exchange`)                                                         |
+| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/oidc_verify.py)                                                                              |
+| Client + settings seed                 | [`core/management/commands/seed.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/management/commands/seed.py) (`seed_sof_ehr_launch_application`, `auth.sof.*`)   |
+| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/tests/backend/test_token_exchange.py)                                            |
+| Reference app (template)               | [jupyterhealth-sof-provider-template](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template) — see also the [MedPlum tutorial](../tutorial/medplum-provider-dashboard.md)    |
+
+## Architecture
+
+```
+                ┌──────────────────── EHR (Epic, Cerner, MedPlum, …) ───────────────────┐
+                │  SMART App Launch (openid fhirUser)                                    │
+  Provider ───▶ │  → issues id_token (iss = EHR, aud = app's EHR client_id, fhirUser)    │
+                └────────────────────────────────────────────────────────────────────────┘
+                                 │  id_token (+ the app's JHE client_id/secret)
+                                 ▼
+  ┌───────────────────── External SMART app (confidential backend) ───────────────────┐
+  │  POST /o/token-exchange  (client auth + subject_token = id_token)                  │
+  └────────────────────────────────────────────────────────────────────────────────────┘
+                                 │
+                                 ▼
+  ┌───────────────────────────── JHE /o/token-exchange ───────────────────────────────┐
+  │  1. Authenticate the confidential client (RFC 6749 client auth)                    │
+  │  2. Read id_token `iss`; require it ∈ auth.sof.trusted_issuers                     │
+  │  3. Discover JWKS: {iss}/.well-known/smart-configuration → jwks_uri                │
+  │  4. Verify signature + exp/iat + aud == auth.sof.trusted_audience                  │
+  │  5. fhirUser ("Practitioner/<id>") → JheUser.identifier == <id>                    │
+  │  6. Issue access token: user = the Practitioner, application = the client          │
+  └────────────────────────────────────────────────────────────────────────────────────┘
+                                 │  { access_token, token_type: Bearer, expires_in }
+                                 ▼
+                 App calls JHE FHIR API with  Authorization: Bearer <access_token>
+```
+
+### Two distinct client identities (do not conflate)
+
+|                              | Where it lives                                | What it is                                             | Checked against            |
+| ---------------------------- | --------------------------------------------- | ------------------------------------------------------ | -------------------------- |
+| **EHR client_id**            | inside the `id_token` as `aud`                | the app's registration **at the EHR**                  | `auth.sof.trusted_audience` |
+| **JHE client_id + secret**   | the token-exchange request (client auth)      | the app's registration **in JHE** ("SoF EHR Launch")   | JHE's OAuth application store |
+
+The `id_token` proves *which provider* is launching; the JHE client credential proves
+*which app* is calling JHE. Both must be satisfied.
+
+## Configuration
+
+### Trust settings (`JheSetting` rows)
+
+Configured at runtime via JheSettings (not env vars). Both are created by
+`python manage.py seed`; update them via the JHE settings admin/API (values are cached
+for ~60s, so a change takes effect within that window):
+
+| Key                         | Type     | Meaning                                                                                     |
+| --------------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `auth.sof.trusted_issuers`  | `json`   | EHR OIDC issuers (`id_token.iss`) whose tokens are accepted; JWKS is discovered from each.  |
+| `auth.sof.trusted_audience` | `string` | The SMART app's `client_id` at the EHR (the `id_token.aud`).                                |
+
+### The "SoF EHR Launch" confidential client
+
+`manage.py seed` also creates a confidential OAuth `Application` named **SoF EHR
+Launch** that external apps authenticate as. The seeded credentials
+(`sof-ehr-launch` / `sof-ehr-launch-dev-secret`) are **dev-only placeholders — rotate
+them for any real deployment** (or override at seed time via
+`SOF_EHR_LAUNCH_CLIENT_ID` / `SOF_EHR_LAUNCH_CLIENT_SECRET`).
+
+The app must run the exchange **server-side** (the template runs it in the Jupyter/Voilà
+backend) so the secret never reaches a browser.
+
+### Per-provider mapping
+
+Each launching clinician must exist in JHE as a `Practitioner` whose
+`JheUser.identifier` equals the **bare FHIR id** from the EHR's `fhirUser` claim
+(`fhirUser: "Practitioner/abc123"` → `identifier == "abc123"`). Unmatched providers
+get `404`.
+
+## The request
+
+`POST /o/token-exchange` — `application/x-www-form-urlencoded`.
+
+| Parameter              | Required | Value                                              |
+| ---------------------- | -------- | --------------------------------------------------- |
+| `grant_type`           | ✓        | `urn:ietf:params:oauth:grant-type:token-exchange`   |
+| `subject_token`        | ✓        | the EHR-issued `id_token` (a JWT)                   |
+| `subject_token_type`   | ✓        | `urn:ietf:params:oauth:token-type:id_token`         |
+| `requested_token_type` | ✓        | `urn:ietf:params:oauth:token-type:access_token`     |
+| `audience`             | ✓        | JHE's site URL (must equal JHE's `SITE_URL` exactly) |
+| `scope`                | ✓        | `openid` (only value supported)                     |
+| `client_id`            | ✓        | the app's JHE confidential client id                |
+| `client_secret`        | ✓        | the app's JHE confidential client secret            |
+
+Client credentials may be sent as form fields (above) or via HTTP Basic
+(`Authorization: Basic …`) — both placements are accepted.
+
+```bash
+curl -X POST 'https://jhe.example/o/token-exchange' \
+  --data-urlencode 'grant_type=urn:ietf:params:oauth:grant-type:token-exchange' \
+  --data-urlencode 'subject_token='"$EHR_ID_TOKEN" \
+  --data-urlencode 'subject_token_type=urn:ietf:params:oauth:token-type:id_token' \
+  --data-urlencode 'requested_token_type=urn:ietf:params:oauth:token-type:access_token' \
+  --data-urlencode 'audience=https://jhe.example' \
+  --data-urlencode 'scope=openid' \
+  --data-urlencode 'client_id=sof-ehr-launch' \
+  --data-urlencode 'client_secret=sof-ehr-launch-dev-secret'
+```
+
+Success (`200`):
+
+```json
+{
+  "access_token": "9f8c…",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 1209600,
+  "scope": "openid"
+}
+```
+
+The issued token is a normal JHE bearer token: it carries the Practitioner's regular
+authorization (organizations → studies → consents), and can be revoked at
+`/o/revoke_token` with the same client credentials. No refresh token is issued; the app
+re-exchanges per launch.
+
+### Errors
+
+| Status | Cause                                                                                              |
+| ------ | --------------------------------------------------------------------------------------------------- |
+| `400`  | Missing/invalid parameter, malformed JWT, wrong `subject_token_type`, `audience` ≠ JHE site URL, missing `fhirUser` |
+| `401`  | Client authentication failed; or `id_token` signature/`exp`/`aud` invalid                           |
+| `403`  | `id_token.iss` not trusted; or `fhirUser` is not a Practitioner                                     |
+| `404`  | No `Practitioner` with `JheUser.identifier` == the `fhirUser` id                                    |
+| `500`  | Token exchange not configured (`auth.sof.*` unset)                                                  |
+| `502`  | JWKS discovery / signing-key resolution failed at the issuer                                        |
+
+## Security notes / known limitations
+
+- **Offline verification, no revocation of the id_token.** A valid `id_token` is honored
+  until its `exp`; an EHR-side session revocation is not reflected until then. Prefer
+  short EHR `id_token` lifetimes.
+- **No replay / one-time-use tracking.** A captured `id_token` can be re-exchanged within
+  its validity window. Client authentication is the primary control; a leaked `id_token`
+  alone is not sufficient without the client secret.
+- **Identity mapping is issuer-unscoped.** `fhirUser` is matched on the bare FHIR id,
+  which assumes **one trusted EHR per JHE instance**. Do not configure issuers from
+  multiple EHRs whose Practitioner ids could collide; `auth.sof.trusted_audience` is
+  likewise a single value.
+- Issued JHE tokens have the standard JHE access-token lifetime (2 weeks by default) and
+  are bound to both the Practitioner and the calling application, so they show up in —
+  and can be revoked through — the normal per-client token management.

--- a/jhe/provider-ehr-launch.md
+++ b/jhe/provider-ehr-launch.md
@@ -2,10 +2,18 @@
 title: Provider EHR Launch (SMART on FHIR)
 ---
 
-An external **SMART on FHIR provider app** — launched from an EHR like Epic, Cerner, or
-MedPlum — can trade the EHR-issued OIDC **`id_token`** for a **JHE user-bound access
-token** over OAuth 2.0 Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)).
-The provider logs in once, at the EHR; there is no second JHE login.
+Clinicians work in the EHR; the remote-monitoring data their patients generate — CGM
+traces, wearable vitals, sleep — lives in JupyterHealth Exchange. This flow puts that
+data **inside the clinical workflow**: the provider opens a patient's chart, clicks a
+JupyterHealth app, and sees that patient's device data right there — already in patient
+context, already authenticated. No separate portal, no second login, no re-finding the
+patient, and JHE's access control still applies (the provider sees only patients they're
+authorized for in JHE).
+
+Technically, the launched app is a **SMART on FHIR provider app** (Epic, Cerner,
+MedPlum, …) that trades the EHR-issued OIDC **`id_token`** for a **JHE user-bound access
+token** over OAuth 2.0 Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) —
+that exchange is what makes the single login possible, and it's what this page documents.
 
 JHE verifies the `id_token` **offline against the EHR's JWKS** (discovered from
 `{iss}/.well-known/smart-configuration`), identifies the provider from the **`fhirUser`**

--- a/jhe/provider-ehr-launch.md
+++ b/jhe/provider-ehr-launch.md
@@ -20,13 +20,13 @@ This is the **provider-side** sibling of the patient-side
 clinical data *into* JHE; this flow lets a provider's launched app read JHE data *out*,
 as that provider, under JHE's normal access control.
 
-| What                                   | Where                                                                                                                                                                                        |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Token-exchange endpoint                | [`core/views/common.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/views/common.py) (`token_exchange`)                                                         |
-| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/oidc_verify.py)                                                                              |
-| Client + settings seed                 | [`core/management/commands/seed.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/management/commands/seed.py) (`seed_sof_ehr_launch_application`, `auth.sof.*`)   |
-| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/tests/backend/test_token_exchange.py)                                            |
-| Reference app (template)               | [jupyterhealth-sof-provider-template](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template) — see also the [MedPlum tutorial](../tutorial/medplum-provider-dashboard.md)    |
+| What                                   | Where                                                                                                                                                                                      |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Token-exchange endpoint                | [`core/views/common.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/views/common.py) (`token_exchange`)                                                        |
+| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/oidc_verify.py)                                                                             |
+| Client + settings seed                 | [`core/management/commands/seed.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/management/commands/seed.py) (`seed_sof_ehr_launch_application`, `auth.sof.*`) |
+| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/tests/backend/test_token_exchange.py)                                           |
+| Reference app (template)               | [jupyterhealth-sof-provider-template](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template) — see also the [MedPlum tutorial](../tutorial/medplum-provider-dashboard.md)   |
 
 ## Architecture
 
@@ -57,10 +57,10 @@ as that provider, under JHE's normal access control.
 
 ### Two distinct client identities (do not conflate)
 
-|                              | Where it lives                                | What it is                                             | Checked against            |
-| ---------------------------- | --------------------------------------------- | ------------------------------------------------------ | -------------------------- |
-| **EHR client_id**            | inside the `id_token` as `aud`                | the app's registration **at the EHR**                  | `auth.sof.trusted_audience` |
-| **JHE client_id + secret**   | the token-exchange request (client auth)      | the app's registration **in JHE** ("SoF EHR Launch")   | JHE's OAuth application store |
+|                            | Where it lives                           | What it is                                           | Checked against               |
+| -------------------------- | ---------------------------------------- | ---------------------------------------------------- | ----------------------------- |
+| **EHR client_id**          | inside the `id_token` as `aud`           | the app's registration **at the EHR**                | `auth.sof.trusted_audience`   |
+| **JHE client_id + secret** | the token-exchange request (client auth) | the app's registration **in JHE** ("SoF EHR Launch") | JHE's OAuth application store |
 
 The `id_token` proves *which provider* is launching; the JHE client credential proves
 *which app* is calling JHE. Both must be satisfied.
@@ -73,10 +73,10 @@ Configured at runtime via JheSettings (not env vars). Both are created by
 `python manage.py seed`; update them via the JHE settings admin/API (values are cached
 for ~60s, so a change takes effect within that window):
 
-| Key                         | Type     | Meaning                                                                                     |
-| --------------------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `auth.sof.trusted_issuers`  | `json`   | EHR OIDC issuers (`id_token.iss`) whose tokens are accepted; JWKS is discovered from each.  |
-| `auth.sof.trusted_audience` | `string` | The SMART app's `client_id` at the EHR (the `id_token.aud`).                                |
+| Key                         | Type     | Meaning                                                                                    |
+| --------------------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `auth.sof.trusted_issuers`  | `json`   | EHR OIDC issuers (`id_token.iss`) whose tokens are accepted; JWKS is discovered from each. |
+| `auth.sof.trusted_audience` | `string` | The SMART app's `client_id` at the EHR (the `id_token.aud`).                               |
 
 ### The "SoF EHR Launch" confidential client
 
@@ -100,16 +100,16 @@ get `404`.
 
 `POST /o/token-exchange` — `application/x-www-form-urlencoded`.
 
-| Parameter              | Required | Value                                              |
-| ---------------------- | -------- | --------------------------------------------------- |
-| `grant_type`           | ✓        | `urn:ietf:params:oauth:grant-type:token-exchange`   |
-| `subject_token`        | ✓        | the EHR-issued `id_token` (a JWT)                   |
-| `subject_token_type`   | ✓        | `urn:ietf:params:oauth:token-type:id_token`         |
-| `requested_token_type` | ✓        | `urn:ietf:params:oauth:token-type:access_token`     |
+| Parameter              | Required | Value                                                |
+| ---------------------- | -------- | ---------------------------------------------------- |
+| `grant_type`           | ✓        | `urn:ietf:params:oauth:grant-type:token-exchange`    |
+| `subject_token`        | ✓        | the EHR-issued `id_token` (a JWT)                    |
+| `subject_token_type`   | ✓        | `urn:ietf:params:oauth:token-type:id_token`          |
+| `requested_token_type` | ✓        | `urn:ietf:params:oauth:token-type:access_token`      |
 | `audience`             | ✓        | JHE's site URL (must equal JHE's `SITE_URL` exactly) |
-| `scope`                | ✓        | `openid` (only value supported)                     |
-| `client_id`            | ✓        | the app's JHE confidential client id                |
-| `client_secret`        | ✓        | the app's JHE confidential client secret            |
+| `scope`                | ✓        | `openid` (only value supported)                      |
+| `client_id`            | ✓        | the app's JHE confidential client id                 |
+| `client_secret`        | ✓        | the app's JHE confidential client secret             |
 
 Client credentials may be sent as form fields (above) or via HTTP Basic
 (`Authorization: Basic …`) — both placements are accepted.
@@ -145,14 +145,14 @@ re-exchanges per launch.
 
 ### Errors
 
-| Status | Cause                                                                                              |
-| ------ | --------------------------------------------------------------------------------------------------- |
+| Status | Cause                                                                                                               |
+| ------ | ------------------------------------------------------------------------------------------------------------------- |
 | `400`  | Missing/invalid parameter, malformed JWT, wrong `subject_token_type`, `audience` ≠ JHE site URL, missing `fhirUser` |
-| `401`  | Client authentication failed; or `id_token` signature/`exp`/`aud` invalid                           |
-| `403`  | `id_token.iss` not trusted; or `fhirUser` is not a Practitioner                                     |
-| `404`  | No `Practitioner` with `JheUser.identifier` == the `fhirUser` id                                    |
-| `500`  | Token exchange not configured (`auth.sof.*` unset)                                                  |
-| `502`  | JWKS discovery / signing-key resolution failed at the issuer                                        |
+| `401`  | Client authentication failed; or `id_token` signature/`exp`/`aud` invalid                                           |
+| `403`  | `id_token.iss` not trusted; or `fhirUser` is not a Practitioner                                                     |
+| `404`  | No `Practitioner` with `JheUser.identifier` == the `fhirUser` id                                                    |
+| `500`  | Token exchange not configured (`auth.sof.*` unset)                                                                  |
+| `502`  | JWKS discovery / signing-key resolution failed at the issuer                                                        |
 
 ## Security notes / known limitations
 

--- a/jhe/provider-ehr-launch.md
+++ b/jhe/provider-ehr-launch.md
@@ -31,9 +31,9 @@ as that provider, under JHE's normal access control.
 | What                                   | Where                                                                                                                                                                                      |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Token-exchange endpoint                | [`core/views/common.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/views/common.py) (`token_exchange`)                                                        |
-| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/oidc_verify.py)                                             |
+| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/oidc_verify.py)                                                                             |
 | Client + settings seed                 | [`core/management/commands/seed.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/management/commands/seed.py) (`seed_sof_ehr_launch_application`, `auth.sof.*`) |
-| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/tests/backend/test_token_exchange.py)           |
+| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/tests/backend/test_token_exchange.py)                                           |
 | Reference app (template)               | [jupyterhealth-sof-provider-template](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template) — see also the [MedPlum tutorial](../tutorial/medplum-provider-dashboard.md)   |
 
 ## Architecture

--- a/jhe/provider-ehr-launch.md
+++ b/jhe/provider-ehr-launch.md
@@ -31,12 +31,13 @@ as that provider, under JHE's normal access control.
 <!-- TODO(flip-to-ready): the oidc_verify.py and test_token_exchange.py links below
      point at the feature branch; switch them to jupyterhealth-exchange main when PR #646
      merges and this PR is marked ready. -->
+
 | What                                   | Where                                                                                                                                                                                      |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Token-exchange endpoint                | [`core/views/common.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/views/common.py) (`token_exchange`)                                                        |
-| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/the-commons-project/jupyterhealth-exchange/blob/ehr-launch-jhe-sso-with-client/core/oidc_verify.py)                                                                             |
+| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/the-commons-project/jupyterhealth-exchange/blob/ehr-launch-jhe-sso-with-client/core/oidc_verify.py)                                             |
 | Client + settings seed                 | [`core/management/commands/seed.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/management/commands/seed.py) (`seed_sof_ehr_launch_application`, `auth.sof.*`) |
-| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/the-commons-project/jupyterhealth-exchange/blob/ehr-launch-jhe-sso-with-client/tests/backend/test_token_exchange.py)                                           |
+| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/the-commons-project/jupyterhealth-exchange/blob/ehr-launch-jhe-sso-with-client/tests/backend/test_token_exchange.py)           |
 | Reference app (template)               | [jupyterhealth-sof-provider-template](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template) — see also the [MedPlum tutorial](../tutorial/medplum-provider-dashboard.md)   |
 
 ## Architecture

--- a/jhe/provider-ehr-launch.md
+++ b/jhe/provider-ehr-launch.md
@@ -28,16 +28,12 @@ This is the **provider-side** sibling of the patient-side
 clinical data *into* JHE; this flow lets a provider's launched app read JHE data *out*,
 as that provider, under JHE's normal access control.
 
-<!-- TODO(flip-to-ready): the oidc_verify.py and test_token_exchange.py links below
-     point at the feature branch; switch them to jupyterhealth-exchange main when PR #646
-     merges and this PR is marked ready. -->
-
 | What                                   | Where                                                                                                                                                                                      |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Token-exchange endpoint                | [`core/views/common.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/views/common.py) (`token_exchange`)                                                        |
-| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/the-commons-project/jupyterhealth-exchange/blob/ehr-launch-jhe-sso-with-client/core/oidc_verify.py)                                             |
+| id_token verification (JWKS discovery) | [`core/oidc_verify.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/oidc_verify.py)                                             |
 | Client + settings seed                 | [`core/management/commands/seed.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/core/management/commands/seed.py) (`seed_sof_ehr_launch_application`, `auth.sof.*`) |
-| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/the-commons-project/jupyterhealth-exchange/blob/ehr-launch-jhe-sso-with-client/tests/backend/test_token_exchange.py)           |
+| Tests                                  | [`tests/backend/test_token_exchange.py`](https://github.com/jupyterhealth/jupyterhealth-exchange/blob/main/tests/backend/test_token_exchange.py)           |
 | Reference app (template)               | [jupyterhealth-sof-provider-template](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template) — see also the [MedPlum tutorial](../tutorial/medplum-provider-dashboard.md)   |
 
 ## Architecture

--- a/jhe/provider-ehr-launch.md
+++ b/jhe/provider-ehr-launch.md
@@ -43,28 +43,33 @@ as that provider, under JHE's normal access control.
 ## Architecture
 
 ```
-                ┌──────────────────── EHR (Epic, Cerner, MedPlum, …) ───────────────────┐
-                │  SMART App Launch (openid fhirUser)                                    │
-  Provider ───▶ │  → issues id_token (iss = EHR, aud = app's EHR client_id, fhirUser)    │
-                └────────────────────────────────────────────────────────────────────────┘
-                                 │  id_token (+ the app's JHE client_id/secret)
-                                 ▼
-  ┌───────────────────── External SMART app (confidential backend) ───────────────────┐
-  │  POST /o/token-exchange  (client auth + subject_token = id_token)                  │
-  └────────────────────────────────────────────────────────────────────────────────────┘
-                                 │
-                                 ▼
-  ┌───────────────────────────── JHE /o/token-exchange ───────────────────────────────┐
-  │  1. Authenticate the confidential client (RFC 6749 client auth)                    │
-  │  2. Read id_token `iss`; require it ∈ auth.sof.trusted_issuers                     │
-  │  3. Discover JWKS: {iss}/.well-known/smart-configuration → jwks_uri                │
-  │  4. Verify signature + exp/iat + aud == auth.sof.trusted_audience                  │
-  │  5. fhirUser ("Practitioner/<id>") → JheUser.identifier == <id>                    │
-  │  6. Issue access token: user = the Practitioner, application = the client          │
-  └────────────────────────────────────────────────────────────────────────────────────┘
-                                 │  { access_token, token_type: Bearer, expires_in }
-                                 ▼
-                 App calls JHE FHIR API with  Authorization: Bearer <access_token>
+               ┌────────────────────────────────────────────────────────────────────────────┐
+               │ EHR (Epic, Cerner, MedPlum, …)                                             │
+  Provider ───▶│ SMART App Launch (openid fhirUser)                                         │
+               │ → issues id_token (iss = EHR OAuth issuer, aud = app's EHR client_id,      │
+               │   fhirUser = the launching Practitioner)                                   │
+               └────────────────────────────────────────────────────────────────────────────┘
+                                                      │  id_token (+ the app's JHE client_id/secret)
+                                                      ▼
+               ┌────────────────────────────────────────────────────────────────────────────┐
+               │ External SMART app (confidential backend)                                  │
+               │ POST /o/token-exchange  (client auth + subject_token = id_token)           │
+               └────────────────────────────────────────────────────────────────────────────┘
+                                                      │
+                                                      ▼
+               ┌────────────────────────────────────────────────────────────────────────────┐
+               │ JHE /o/token-exchange                                                      │
+               │ 1. Authenticate the confidential client (RFC 6749 client auth)             │
+               │ 2. Read id_token `iss`; require it ∈ auth.sof.trusted_issuers              │
+               │ 3. Discover JWKS: {iss}/.well-known/smart-configuration → jwks_uri         │
+               │    (falls back to {iss}/.well-known/openid-configuration)                  │
+               │ 4. Verify signature + exp/iat + aud == auth.sof.trusted_audience           │
+               │ 5. fhirUser ("Practitioner/<id>") → JheUser.identifier == <id>             │
+               │ 6. Issue access token: user = the Practitioner, application = the client   │
+               └────────────────────────────────────────────────────────────────────────────┘
+                                                      │  { access_token, token_type: Bearer, expires_in }
+                                                      ▼
+                     App calls JHE FHIR API with  Authorization: Bearer <access_token>
 ```
 
 ### Two distinct client identities (do not conflate)

--- a/jhe/provider-ehr-launch.md
+++ b/jhe/provider-ehr-launch.md
@@ -90,6 +90,13 @@ for ~60s, so a change takes effect within that window):
 | `auth.sof.trusted_issuers`  | `json`   | EHR OIDC issuers (`id_token.iss`) whose tokens are accepted; JWKS is discovered from each. |
 | `auth.sof.trusted_audience` | `string` | The SMART app's `client_id` at the EHR (the `id_token.aud`).                               |
 
+> **The issuer is the id_token's literal `iss` — usually the EHR's OAuth server, not
+> its FHIR base.** Epic's sandbox, for example, issues
+> `https://fhir.epic.com/interconnect-fhir-oauth/oauth2` (JWKS discovery resolves there
+> via the `openid-configuration` fallback). MedPlum is the outlier: its `iss` is the
+> FHIR base URL, with a trailing slash. When in doubt, decode a captured id_token and
+> copy its `iss` verbatim.
+
 ### The "SoF EHR Launch" confidential client
 
 `manage.py seed` also creates a confidential OAuth `Application` named **SoF EHR

--- a/myst.yml
+++ b/myst.yml
@@ -30,6 +30,7 @@ project:
         - file: jhe/patient-identifiers.md
         - file: jhe/ow-integration.md
         - file: jhe/mychart-integration.md
+        - file: jhe/provider-ehr-launch.md
         - file: jhe/mcp-server.md
         # - title: Deploy
         #   children:
@@ -44,6 +45,7 @@ project:
         # - file: tutorial/exchange-on-kubernetes.md
         - file: tutorial/openmhealth-bp.ipynb
         - file: tutorial/tutorial-cgm.ipynb
+        - file: tutorial/medplum-provider-dashboard.md
     # - title: How-To Guides
     #   children:
     #     - title: For Admins and Deployment

--- a/tutorial/index.md
+++ b/tutorial/index.md
@@ -8,6 +8,8 @@ Note: [the difference between how-to and tutorial](https://diataxis.fr/tutorials
 
 ## Available Tutorials
 
+- **[Launch a JupyterHealth dashboard via SMART on FHIR (MedPlum example)](medplum-provider-dashboard.md)** - Build a provider-facing dashboard app that launches from an EHR, exchanges the EHR login for JHE access, and renders the launched patient's device data
+
 <!-- - **[Your First Local JupyterHealth Exchange](local-exchange-deployment.md)** - Deploy JupyterHealth Exchange on your computer in 15 minutes and explore example research data
 - **[Deploying JupyterHealth Exchange on Kubernetes](exchange-on-kubernetes.md)** - Deploy a production JupyterHealth Exchange on AWS with Kubernetes -->
 
@@ -19,7 +21,6 @@ Note: [the difference between how-to and tutorial](https://diataxis.fr/tutorials
 - Running Your First Analysis in a Notebook
 - Deploying a standalone JupyterHealth Hub
 - Fetching and viewing data from the Exchange with JupyterHealth Client
-- Launch a JupyterHealth-powered dashboard via SMART-on-FHIR (medplum example)
 
 Borderline tutorial/how-to depending on what we choose to write:
 

--- a/tutorial/medplum-provider-dashboard.md
+++ b/tutorial/medplum-provider-dashboard.md
@@ -1,0 +1,115 @@
+---
+title: "Launch a JupyterHealth dashboard via SMART on FHIR (MedPlum example)"
+---
+
+In this tutorial you stand up a **provider-facing dashboard app** that a clinician
+launches from an EHR. The EHR launch is the only login: the app exchanges the EHR's
+`id_token` for a JupyterHealth Exchange token behind the scenes (see
+[Provider EHR Launch](../jhe/provider-ehr-launch.md)), joins the launched patient to
+their JHE record by MRN, and renders that patient's device data (CGM, wearables) in a
+Voilà notebook.
+
+[MedPlum](https://www.medplum.com) plays the EHR here because its hosted sandbox is
+free and takes minutes to configure — but nothing below is MedPlum-specific: the same
+app launches from any SMART-enabled EHR by changing only registration values (see the
+[template's EHR registration guide](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template/blob/main/docs/ehr-registration.md)
+for Epic notes, including its stricter scope grammar).
+
+**What you need:**
+
+- A [MedPlum account](https://app.medplum.com) with a project you administer.
+- A **JupyterHealth Exchange** instance with the token exchange configured — a local
+  dev instance works. You'll need its `SITE_URL`, the "SoF EHR Launch" client
+  credentials, and admin access to its settings
+  ([how that works](../jhe/provider-ehr-launch.md)).
+- A JHE **patient with device data** (the seed data works) and a JHE **practitioner**
+  account for yourself.
+- Docker.
+
+## 1. Create the app from the template
+
+Generate your app from
+[jupyterhealth-sof-provider-template](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template)
+("Use this template", or clone it) and follow its
+[QUICKSTART](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template/blob/main/docs/QUICKSTART.md)
+through the `.env` step. The values that matter for this tutorial:
+
+```
+JHE_URL=<your JHE base URL — must equal the JHE instance's SITE_URL exactly>
+JHE_CLIENT_ID=<the JHE "SoF EHR Launch" client id>
+JHE_CLIENT_SECRET=<its secret>
+SMART_CLIENT_ID=<from step 2 below>
+SMART_SCOPES=openid fhirUser launch patient/*.read
+MRN_IDENTIFIER_SYSTEM=<any URI you choose — you control both sides; e.g. https://example.org/mrn>
+```
+
+Then run it: `docker compose up --build` — the app listens on `http://localhost:8888`
+and does nothing until an EHR launches it.
+
+## 2. Register the app in MedPlum
+
+In your MedPlum project: **Admin → Project → Clients → New**, and set:
+
+- **Launch URI:** `http://localhost:8888/smart-on-fhir/launch`
+- **Redirect URI:** `http://localhost:8888/smart-on-fhir/callback`
+- **PKCE enabled; no client secret required** (the app is a public client toward the
+  EHR — its only secret is the JHE one, which never goes to MedPlum).
+
+Copy the client's **ID** into `SMART_CLIENT_ID` in your `.env`.
+
+## 3. Configure JHE to trust the launch
+
+On the JHE side ([details](../jhe/provider-ehr-launch.md#configuration)):
+
+- `auth.sof.trusted_issuers` → `["https://api.medplum.com/"]`
+- `auth.sof.trusted_audience` → your MedPlum client ID from step 2
+- Your JHE practitioner's `identifier` → your **MedPlum Practitioner ID** (open your
+  practitioner profile in MedPlum; the id is in the URL — the `fhirUser` claim in the
+  launch id_token carries the same value).
+
+## 4. Create the demo patient (the MRN join)
+
+The app finds the JHE patient whose **external identifier equals the EHR patient's MRN
+value**. Create a MedPlum `Patient` mirroring a JHE patient with data, e.g. the seeded
+CGM patient:
+
+| Field                       | Value                                              |
+| --------------------------- | --------------------------------------------------- |
+| Name / birth date           | copy from the JHE patient (e.g. May Nguyen, 1984-07-11) |
+| `Patient.identifier.system` | your `MRN_IDENTIFIER_SYSTEM` from step 1            |
+| `Patient.identifier.value`  | the JHE patient's external id (e.g. `1636-69-001`)  |
+
+Name and birth date must match the JHE record — the app verifies the two records are
+the same person before showing anything (it fails closed with a lock notice if not).
+Identifier *values* must be equal; the identifier *systems* on each side need not agree.
+
+## 5. Launch
+
+In MedPlum, open the patient → **Apps** → click your app. MedPlum redirects through
+`/smart-on-fhir/launch`, asks you to authorize, and returns to the callback — at which
+point the app exchanges the id_token with JHE and renders the dashboard:
+the patient's demographics header and their device data, fetched from JHE **as you**,
+under your normal JHE authorization. No JHE login screen ever appears.
+
+On the JHE side you can watch it happen — the log records the exchange:
+
+```
+Token exchange: issued JHE token for Practitioner '<your id>' from issuer
+https://api.medplum.com/ to client 'sof-ehr-launch'
+```
+
+If you get a lock notice or an error page instead, the
+[QUICKSTART troubleshooting table](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template/blob/main/docs/QUICKSTART.md#troubleshooting)
+maps each symptom to its cause — the failure point (trust config, practitioner mapping,
+MRN join) is always identifiable from which message you see.
+
+## Where to go from here
+
+- Put your own analytics in `dashboard.ipynb` (the cell marked
+  `ADD YOUR ANALYTICS + VISUALIZATION`); the launch/data plumbing above it doesn't change.
+- Try the richer CGM showcase: `cp examples/cgm-dashboard.ipynb dashboard.ipynb`.
+- Register with a real EHR and deploy: the template's
+  [ehr-registration](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template/blob/main/docs/ehr-registration.md)
+  and
+  [deployment](https://github.com/jupyterhealth/jupyterhealth-sof-provider-template/blob/main/docs/deployment.md)
+  guides cover Epic specifics (scope grammar, iframe/CSP) and hosting.

--- a/tutorial/medplum-provider-dashboard.md
+++ b/tutorial/medplum-provider-dashboard.md
@@ -1,5 +1,5 @@
 ---
-title: "Launch a JupyterHealth dashboard via SMART on FHIR (MedPlum example)"
+title: Launch a JupyterHealth dashboard via SMART on FHIR (MedPlum example)
 ---
 
 In this tutorial you stand up a **provider-facing dashboard app** that a clinician
@@ -73,11 +73,11 @@ The app finds the JHE patient whose **external identifier equals the EHR patient
 value**. Create a MedPlum `Patient` mirroring a JHE patient with data, e.g. the seeded
 CGM patient:
 
-| Field                       | Value                                              |
-| --------------------------- | --------------------------------------------------- |
+| Field                       | Value                                                   |
+| --------------------------- | ------------------------------------------------------- |
 | Name / birth date           | copy from the JHE patient (e.g. May Nguyen, 1984-07-11) |
-| `Patient.identifier.system` | your `MRN_IDENTIFIER_SYSTEM` from step 1            |
-| `Patient.identifier.value`  | the JHE patient's external id (e.g. `1636-69-001`)  |
+| `Patient.identifier.system` | your `MRN_IDENTIFIER_SYSTEM` from step 1                |
+| `Patient.identifier.value`  | the JHE patient's external id (e.g. `1636-69-001`)      |
 
 Name and birth date must match the JHE record — the app verifies the two records are
 the same person before showing anything (it fails closed with a lock notice if not).


### PR DESCRIPTION
Documents the SMART on FHIR **provider EHR-launch** flow and its reference app. Draft until the code it documents merges:

- jupyterhealth/jupyterhealth-exchange#646 (id_token token exchange with the confidential-client rework)
- jupyterhealth/jupyterhealth-sof-provider-template#16 (template: client-authenticated exchange)

## What's here

- **`jhe/provider-ehr-launch.md`** — integration page in the JHE section (house style of `mychart-integration.md`, of which it is the provider-side sibling): the clinical benefit up front, architecture, the two client identities, `auth.sof.*` trust settings, the seeded "SoF EHR Launch" confidential client, RFC 8693 request/response, error table, security notes. This gives `TOKEN_EXCHANGE_TMP_README.md` (currently a temp file on the JHE branch) its permanent home — that file can be deleted when #646 lands.
- **`tutorial/medplum-provider-dashboard.md`** — writes the long-planned *"Launch a JupyterHealth-powered dashboard via SMART-on-FHIR (medplum example)"* tutorial: template → MedPlum registration → JHE trust → MRN join → launch. Mechanics defer by link to the template's own QUICKSTART (one home per fact). Grounded in the validated end-to-end MedPlum run (2026-07).
- TOC + tutorial index updates.

## Before marking ready

Two What/Where links (`core/oidc_verify.py`, `tests/backend/test_token_exchange.py`) currently point at the feature branch so they resolve for reviewers and keep the link check green; a `TODO(flip-to-ready)` comment in the page marks them to switch to `main` once #646 merges.