### PR TITLE
ci: ignore the flaky doi.org citation lookup in tutorial-cgm

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -88,6 +88,13 @@ project:
         - "http://localhost:8010/smart/callback"
         # epic.com blocks automated requests (403), so the checker can't verify it
         - "https://www.epic.com/software/mychart/"
+    # doi.org intermittently rate-limits CI runners; this citation lookup in
+    # tutorial-cgm.ipynb has flaked repeatedly (2026-07-12, 2026-07-15).
+    - rule: doi-link-valid
+      severity: ignore
+      keys:
+        - "10.1371/journal.pbio.2005143.s010"
+        - "doi:10.1371/journal.pbio.2005143.s010"
 site:
   template: book-theme
   title: JupyterHealth Software


### PR DESCRIPTION
The `test-docs` strict check has failed twice in three days (2026-07-12, 2026-07-15) on the same doi.org citation lookup in `tutorial-cgm.ipynb` — doi.org intermittently rate-limits GitHub's runners; both failures passed on plain rerun. Adds a `doi-link-valid` ignore for that one DOI, same pattern as the existing epic.com link ignore. The citation itself is unchanged and still renders.