### PR TITLE
docs(jhe): FHIR discovery endpoints + updated MCP server tools

### DIFF
--- a/jhe/auth.md
+++ b/jhe/auth.md
@@ -9,6 +9,8 @@ The OAuth 2.0 Authorization Code flow with PKCE is used to issue access and refr
 Endpoints and configuration details can be discovered from the OIDC metadata endpoint:
 `/o/.well-known/openid-configuration`
 
+FHIR/SMART clients can equivalently discover the `authorize` and `token` endpoints from the [SMART App Launch discovery document](../reference/exchange-apis.md) at `/fhir/r5/.well-known/smart-configuration` (or the CapabilityStatement at `/fhir/r5/metadata`), so public PKCE clients need no hardcoded endpoint configuration.
+
 Separate OAuth clients are created for the Web UI (Practitioners) and for individual JHE (Patient) Clients.
 
 ### JHE Client Auth Flow

--- a/jhe/mcp-server.md
+++ b/jhe/mcp-server.md
@@ -209,6 +209,8 @@ fly status -a jhe-mcp    # machine / image status
 
 The MCP server exposes the following tools to LLM clients. Every tool runs as the authenticated user and only returns data that user is authorized to see.
 
+The observation and patient-search tools use JHE's FHIR search support (the `date` search parameter, `_summary=count`, `_sort`, and the Patient search parameters). **Deploy order matters:** roll out a JHE backend that has this search support before deploying the MCP server against it — an older backend silently ignores unknown search parameters, which corrupts sorted queries rather than merely widening date windows. When the backend publishes a CapabilityStatement (`/fhir/r5/metadata`), the MCP server checks requested search parameters against it and returns a clear error for unsupported ones instead of letting them be silently ignored; against a backend without the endpoint it falls back to sending them as-is.
+
 **Studies:**
 
 - **`get_study_count`** - Returns the total number of studies the authenticated user can access.
@@ -218,19 +220,24 @@ The MCP server exposes the following tools to LLM clients. Every tool runs as th
 
 **Patients:**
 
+- **`search_patients`** - Finds patients by `name`/`family`/`given` (case-insensitive prefix match; a comma ORs values) and/or `birthdate` (`YYYY-MM-DD`, optional `ge`/`le`/`gt`/`lt` prefix), returning a page of slim demographics. At least one criterion is required; `limit` is capped at 1000.
 - **`get_patient_demographics`** - Returns demographic information for a specific patient by patient ID.
-- **`get_patient_date_range`** - Returns the earliest and latest observation dates and total count for a patient (first/last-data answers without paging).
+- **`get_patient_date_range`** - Returns the earliest and latest observation dates and total count for a patient, using two small server-side sorted probes (no paging through records).
 
 **Observations:**
 
 - **`count_patient_observations`** - Returns the exact observation count for a patient, optionally filtered by OMH data type and date range, without returning records.
 - **`count_study_observations`** - Returns the observation count across a whole study in one call; with `by_patient=True` returns a `{patient_id: count}` map.
-- **`summarize_patient_observations`** - Returns a compact per-data-type digest for a patient (`{type: {count, earliest, latest}}`) - the "show me everything" overview.
-- **`get_patient_observations`** - Fetches one page of a patient's observations (with total/pagination), optionally filtered by OMH data type and date range; defaults to compact records, with `verbosity="full"` for the raw OMH body.
+- **`summarize_patient_observations`** - Returns a compact per-data-type digest for a patient (`{truncated, types: {type: {count, earliest, latest}}}`) - the "show me everything" overview. `truncated: true` means the bounded fetch could not cover every record, so counts are lower bounds.
+- **`get_patient_observations`** - Fetches one page of a patient's observations (with total/pagination), optionally filtered by OMH data type and an inclusive `start`/`end` date window (applied server-side, compared in the server's timezone — UTC by default), ordered `newest` (default) or `oldest`; defaults to compact records, with `verbosity="full"` for the raw OMH body.
 
 **OMH schemas:**
 
 - **`get_omh_schema`** - Returns the full OMH JSON schema for a data type by short name (e.g. `heart-rate`, `blood-glucose`). Schemas are also browsable as resources at `omh://schema/<name>`.
+
+**Capabilities:**
+
+- **`get_server_capabilities`** - Returns a digest of the JHE instance's CapabilityStatement (`{available, fhir_version, resources: {type: {interactions, search_params}}}`) so a client can ask what this deployment supports; `available: false` means the instance predates the metadata endpoint.
 
 ## Local Development
 

--- a/reference/exchange-apis.md
+++ b/reference/exchange-apis.md
@@ -131,6 +131,69 @@ code=4AWKhgaaomTSf9PfwxN4ExnXjdSEqh&grant_type=authorization_code&redirect_uri=h
 
 ## FHIR REST API
 
+### Discovery
+
+- The FHIR API publishes two public discovery documents. Both require **no authentication** (they work even if an invalid token is attached), send permissive CORS headers so browser apps can fetch them cross-origin, and are cacheable (`Cache-Control: max-age=3600`).
+- `GET /fhir/r5/metadata` returns the server's **CapabilityStatement** (FHIR R5, `kind: instance`). It is rendered from the server's FHIR mapping configuration at request time, so it always reflects what the running deployment actually supports — resource types, allowed interactions, and search parameters — and it negotiates `application/fhir+json` as well as plain JSON.
+
+```json
+// GET /fhir/r5/metadata (abridged)
+{
+    "resourceType": "CapabilityStatement",
+    "status": "active",
+    "kind": "instance",
+    "fhirVersion": "5.0.0",
+    "format": ["json"],
+    "rest": [
+        {
+            "mode": "server",
+            "security": {
+                "extension": [
+                    {
+                        "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
+                        "extension": [
+                            { "url": "authorize", "valueUri": "https://jhe.fly.dev/o/authorize/" },
+                            { "url": "token", "valueUri": "https://jhe.fly.dev/o/token/" }
+                        ]
+                    }
+                ],
+                "service": [{ "coding": [{ "code": "SMART-on-FHIR" }] }]
+            },
+            "resource": [
+                {
+                    "type": "Observation",
+                    "interaction": [{ "code": "create" }, { "code": "read" }, { "code": "search-type" }, ...],
+                    "searchParam": [{ "name": "date", "type": "date" }, { "name": "code", "type": "token" }, ...]
+                },
+                ...
+            ]
+        }
+    ]
+}
+```
+
+- Reading the CapabilityStatement correctly requires knowing that JHE serves resources from **two stores**: JHE-native records (backed by Django models) and imported records (opaque FHIR bodies linked to a registered FHIR source). Each resource entry declares the **union** of both stores' capabilities, with the caveats spelled out in its `documentation`:
+  - `update`, `patch`, and `delete` apply to **imported records only**; JHE-native records are read-only through FHIR (writes return `405`).
+  - Creates routed to the imported-record store must name a FHIR source via the `X-JHE-FHIR-Source-ID` header or the resource's `meta.source`.
+  - Search parameters declared only by the imported-record store (their `documentation` says so) apply only when selecting that store with `_source`; the default JHE-native search ignores them.
+  - JHE-native Observations code their measurement with system `https://w3id.org/openmhealth` and carry the full Open mHealth data point as a base64 JSON `valueAttachment`.
+- Every resource also supports `_id`, `_lastUpdated`, and `_source` search parameters, plus `_sort` (`date`, `lastUpdated`) and `_summary=count`; each declared interaction and parameter carries the US Core expectation extension (`SHALL`).
+- `GET /fhir/r5/.well-known/smart-configuration` returns the **SMART App Launch discovery document** — how a client (especially a public PKCE client) finds the OAuth endpoints without hardcoding them:
+
+```json
+// GET /fhir/r5/.well-known/smart-configuration
+{
+    "authorization_endpoint": "https://jhe.fly.dev/o/authorize/",
+    "token_endpoint": "https://jhe.fly.dev/o/token/",
+    "grant_types_supported": ["authorization_code"],
+    "response_types_supported": ["code"],
+    "code_challenge_methods_supported": ["S256"],
+    "capabilities": ["launch-standalone", "client-public", "client-confidential-symmetric"]
+}
+```
+
+- Both documents derive their absolute URLs from the request host, so every JHE deployment automatically advertises its own endpoints.
+
 ### Patients
 
 - The `FHIR Patient` endpoint returns a list of Patients as a FHIR Bundle for a given Study ID passed as query parameter`_has:Group:member:_id` or alternatively a single Patient matching the query parameter `identifier=<system>|<value>`


### PR DESCRIPTION
## Summary

Documents the discovery surface added in jupyterhealth/jupyterhealth-exchange#676 and the MCP server updates from jupyterhealth/jupyterhealth-exchange#674:

- **reference/exchange-apis.md** — new *Discovery* subsection under the FHIR REST API: `GET /fhir/r5/metadata` (CapabilityStatement — public/CORS/cacheable, `application/fhir+json`, how to read the dual-store entries: update/patch/delete are imported-records-only, aux-only search params need `_source`, OMH `valueAttachment` encoding on native Observations, common `_id`/`_lastUpdated`/`_source`/`_sort`/`_summary` params) and `GET /fhir/r5/.well-known/smart-configuration` (SMART App Launch discovery for public PKCE clients), with example responses.
- **jhe/mcp-server.md** — tool list updated: `search_patients`, ordering + server-side date filtering on `get_patient_observations`, the `{truncated, types}` summarize envelope, two-probe `get_patient_date_range`, new `get_server_capabilities`, plus the backend requirement and deploy-order note.
- **jhe/auth.md** — one paragraph linking the SMART discovery document next to the existing OIDC metadata endpoint.

## Status

**Draft until the exchange PRs (#674/#676) merge and deploy** — will flip ready once the live endpoints are verified, so the site never documents endpoints that 401.

`myst build --html --check-links --strict` passes (only pre-existing implicit-heading warnings).